### PR TITLE
Potential fix for code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -4,7 +4,7 @@ from functools import wraps
 from typing import Any, Callable
 
 import jwt
-from flask import Blueprint, Request, current_app, jsonify, request, send_file
+from flask import Blueprint, Request, current_app, jsonify, request, send_file, escape
 from flask.wrappers import Response
 from werkzeug.utils import secure_filename
 
@@ -177,6 +177,7 @@ def _validate_upload_request(request: Request) -> tuple[Any, Any, Any, Any, Any,
             file_name = request.form.get("file_name")
             if not file_name:
                 file_name = secure_filename(file.filename or "")
+            file_name = escape(file_name)
 
             iv_file = request.form.get("iv_file")
             assoc_data_file = request.form.get("assoc_data_file")


### PR DESCRIPTION
Potential fix for [https://github.com/Nanda128/CloudWorx-Backend/security/code-scanning/5](https://github.com/Nanda128/CloudWorx-Backend/security/code-scanning/5)

To fix the issue, we need to ensure that all user-provided input included in the `error_response` is properly sanitized or escaped. Since the `jsonify` function is used to construct the response, it is generally safe for JSON contexts. However, to be extra cautious, we should explicitly sanitize or escape user input before including it in the response. This can be done using the `flask.escape` function for strings or equivalent sanitization methods.

The fix involves:
1. Escaping or sanitizing all user-provided input (e.g., `file_name`) before including it in the `error_response`.
2. Ensuring that all fields in the `error_response` are safe for rendering in a browser.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
