### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/AutoDeploy.yaml
+++ b/.github/workflows/AutoDeploy.yaml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Nanda128/CloudWorx-Backend/security/code-scanning/1](https://github.com/Nanda128/CloudWorx-Backend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the `contents` permission to `read`, as the workflow does not require any write permissions or other elevated privileges. This change ensures that the `GITHUB_TOKEN` is restricted to the minimal permissions necessary for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
